### PR TITLE
Year and contributors added

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) [year] [fullname]
+Copyright (c) 2021 Kyle Ahn, Mukund Iyer, Rada Rudyak, Chaoran Wang
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The year of the license and the names of the contributors to the project have been added. Multiple contributors have been added with the reference of:
 https://law.stackexchange.com/questions/16847/how-should-multiple-copyright-holders-be-credited-using-the-mit-license